### PR TITLE
Do not force compliance to Identifiable

### DIFF
--- a/Sources/StadiaMapsAutocompleteSearch/AutocompleteSearch.swift
+++ b/Sources/StadiaMapsAutocompleteSearch/AutocompleteSearch.swift
@@ -64,7 +64,7 @@ public struct AutocompleteSearch<T: View>: View {
 
         ZStack {
             List {
-                ForEach(searchResults) { result in
+                ForEach(searchResults, id: \.properties.gid) { result in
                     makeResultView(feature: result, relativeTo: userLocation)
                 }
             }

--- a/Sources/StadiaMapsAutocompleteSearch/Extensions.swift
+++ b/Sources/StadiaMapsAutocompleteSearch/Extensions.swift
@@ -3,12 +3,6 @@ import CoreLocation
 import StadiaMaps
 import SwiftUI
 
-extension FeaturePropertiesV2: Identifiable {
-    public var id: String? {
-        properties.gid
-    }
-}
-
 /// Legacy support until we have a v2 /search endpoint
 public extension GeocodingGeoJSONFeature {
     var subtitle: String? {


### PR DESCRIPTION
```
Extension declares a conformance of imported type 'FeaturePropertiesV2' to imported protocol 'Identifiable'; this will not behave correctly if the owners of 'StadiaMaps' introduce this conformance in the future
```